### PR TITLE
Mm update

### DIFF
--- a/geth/index.js
+++ b/geth/index.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process');
 console.log("Starting up geth node...")
 try{
 
-  exec('./go-ethereum/build/bin/geth --rpcport 48545 --allow-insecure-unlock --cache=4096 --maxpeers=50 --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi="db,eth,net,web3,personal,admin,debug,miner,txpool" >> ./geth.log 2>&1', (err, stdout, stderr) => {
+  exec('./go-ethereum/build/bin/geth --http.port 48545 --allow-insecure-unlock --cache=4096 --maxpeers=50 --http --http.addr "0.0.0.0" --http.corsdomain "*" --http.api="eth,net,web3,personal,admin,debug,miner,txpool" >> ./geth.log 2>&1', (err, stdout, stderr) => {
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
   })

--- a/geth/index.js
+++ b/geth/index.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process');
 console.log("Starting up geth node...")
 try{
 
-  exec('./go-ethereum/build/bin/geth --http.port 48545 --allow-insecure-unlock --cache=4096 --maxpeers=50 --http --http.addr "0.0.0.0" --http.corsdomain "*" --http.api="eth,net,web3,personal,admin,debug,miner,txpool" >> ./geth.log 2>&1', (err, stdout, stderr) => {
+  exec('./go-ethereum/build/bin/geth --rpcport 48545 --allow-insecure-unlock --cache=4096 --maxpeers=50 --rpc --rpcaddr "0.0.0.0" --rpccorsdomain "*" --rpcapi="db,eth,net,web3,personal,admin,debug,miner,txpool" >> ./geth.log 2>&1', (err, stdout, stderr) => {
     console.log(`stdout: ${stdout}`);
     console.log(`stderr: ${stderr}`);
   })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/react-fontawesome": "^0.1.5",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^4.5.1",
+    "@metamask/detect-provider": "^1.2.0",
     "@portis/web3": "^2.0.0-beta.54",
     "@toruslabs/torus-embed": "^1.0.0",
     "@walletconnect/web3-provider": "^1.0.0-beta.47",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "color-mixer": "^1.0.0",
     "dapparatus": "^1.0.96",
     "eth-crypto": "^1.5.0",
+    "eth-sig-util": "^3.0.1",
     "ethashjs": "^0.0.7",
     "ethereum-checksum-address": "^0.0.5",
     "ethereum-ens": "^0.7.8",

--- a/src/nodes/Components/MetaMask.js
+++ b/src/nodes/Components/MetaMask.js
@@ -45,10 +45,7 @@ MetaMask.prototype.connectWeb3 = async function() {
 }
 
 MetaMask.prototype.onExecute = async function() {
-
-
   this.connectWeb3()
-  this.setOutputData(0, this.accounts[0])
 
   this.setOutputData(1,{
     name:"balance",
@@ -74,7 +71,6 @@ MetaMask.prototype.onExecute = async function() {
     function:async (args)=>{
       await new Promise ((resolve, reject) => {
         this.onAction()
-        this.Web3 = new Web3(window.ethereum)
         const from = this.accounts[0]
         window.ethereum.request({
           method: 'personal_sign',

--- a/src/nodes/Components/MetaMask.js
+++ b/src/nodes/Components/MetaMask.js
@@ -152,7 +152,7 @@ MetaMask.prototype.onExecute = async function() {
           return console.error(error)
         })
 
-      });
+      })
     }
   })
 
@@ -160,28 +160,22 @@ MetaMask.prototype.onExecute = async function() {
     name:"signedTypedData",
     args:[{name:"typedData",type:"object"}],
     function:async (args)=>{
-      return new Promise((resolve, reject) => {
+      await new Promise((resolve, reject) => {
         this.onAction()
         window.ethereum.request({
           id: 1,
           method: "eth_signTypedData_v3",
           params: [this.accounts[0], JSON.stringify(args.typedData)],
           from: this.accounts[0] 
-        }, (error,result)=>{
-          console.log("SEND MM CALLBACK",error,result)
-          if(error&&error.message){
-            global.setSnackbar({msg:error.message})
-            console.log("REJECT",result)
-            reject(error)
-          }else{
-            console.log("RESOLVE",result)
-            const r = result.result.slice(0,66)
-            const s = '0x' + result.result.slice(66,130)
-            const v = Number('0x' + result.result.slice(130,132))
-            resolve(result.result)
-          }
         })
-      });
+        .then((result) => {
+          resolve(console.log(result))
+        })
+        .catch((error) => {
+          reject(console.error(error))
+        })
+      })
+      
     }
   })
 

--- a/src/nodes/Components/MetaMask.js
+++ b/src/nodes/Components/MetaMask.js
@@ -101,32 +101,6 @@ MetaMask.prototype.onExecute = async function() {
         }).catch((error) => {
           return console.error(error)
         })
-      //   window.ethereum.sendAsync({
-      //     method: 'personal_sign',
-      //     params: [args.message, from],
-      //     from: from,
-      //   }, function (error, result) { 
-          // if (error) return console.error(error)
-          // if (result.error) return console.error(result.error)
-          // console.dir(result)
-          // console.log('PERSONAL SIGNED: ' + JSON.stringify(result.result))
-          // console.log('recovering...')
-          // const msgParams = { data: args.message }
-          // msgParams.sig = result.result
-          // const recovered = sigUtil.recoverPersonalSignature(msgParams)
-          // console.dir({ recovered })
-
-          // if (recovered === from ) {
-          //   console.log('SigUtil Successfully verified signer as ' + from)
-          //   resolve(window.alert('SigUtil Successfully verified signer as ' + from))
-          // } else {
-          //   console.dir(recovered)
-          //   console.log('SigUtil Failed to verify signer when comparing ' + recovered.result + ' to ' + from)
-          //   reject(console.log('Failed, comparing %s to %s', recovered, from))
-          // }
-      //   })
-      // }) 
-    
     })
   }})
 

--- a/src/nodes/Components/MetaMask.js
+++ b/src/nodes/Components/MetaMask.js
@@ -30,7 +30,8 @@ MetaMask.prototype.connectWeb3 = async function() {
   const provider = detectEthereumProvider
   if (provider) {
     try {
-      this.accounts = this.accounts ? this.accounts : await window.ethereum.request({ method: 'eth_requestAccounts' })
+      this.accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
+      this.setOutputData(0, this.accounts[0])
     } catch (error) {
         if (error.code === 4001) {
           console.log('Please connect to MetaMask!')

--- a/src/nodes/Components/Wallet.js
+++ b/src/nodes/Components/Wallet.js
@@ -78,7 +78,7 @@ Wallet.prototype.onExecute = async function () {
     function: async (args) => {
       try {
         this.onAction();
-        let currentWeb3 = new Web3(window.web3);
+        let currentWeb3 = new Web3(window.ethereum);
         let balance = await currentWeb3.eth.getBalance(args.address);
         return balance;
       } catch (e) {
@@ -92,7 +92,6 @@ Wallet.prototype.onExecute = async function () {
     function: async (args) => {
       return new Promise((resolve, reject) => {
         this.onAction();
-        let currentWeb3 = new Web3(window.web3);
         window.ethereum.sendAsync(
           {
             method: "personal_sign",
@@ -126,7 +125,7 @@ Wallet.prototype.onExecute = async function () {
     function: async (args) => {
       return new Promise((resolve, reject) => {
         this.onAction();
-        let currentWeb3 = new Web3(window.web3);
+        let currentWeb3 = new Web3(window.ethereum);
 
         const transactionParameters = {
           //gasPrice: '0x09184e72a000', // customizable by user during MetaMask confirmation.

--- a/src/nodes/Components/Wallet.js
+++ b/src/nodes/Components/Wallet.js
@@ -78,9 +78,10 @@ Wallet.prototype.onExecute = async function () {
     function: async (args) => {
       try {
         this.onAction();
-        let currentWeb3 = new Web3(window.ethereum);
+        let currentWeb3 = new Web3(window.web3);
         let balance = await currentWeb3.eth.getBalance(args.address);
-        return balance;
+        let eth_balance = currentWeb3.utils.fromWei(balance)
+        return eth_balance;
       } catch (e) {
         console.log(e);
       }
@@ -91,6 +92,7 @@ Wallet.prototype.onExecute = async function () {
     args: [{ name: "message", type: "string" }],
     function: async (args) => {
       return new Promise((resolve, reject) => {
+        let currentWeb3 = new Web3(window.web3);
         this.onAction();
         window.ethereum.sendAsync(
           {
@@ -125,7 +127,7 @@ Wallet.prototype.onExecute = async function () {
     function: async (args) => {
       return new Promise((resolve, reject) => {
         this.onAction();
-        let currentWeb3 = new Web3(window.ethereum);
+        let currentWeb3 = new Web3(window.web3);
 
         const transactionParameters = {
           //gasPrice: '0x09184e72a000', // customizable by user during MetaMask confirmation.

--- a/src/nodes/Components/Wallet.js
+++ b/src/nodes/Components/Wallet.js
@@ -80,8 +80,7 @@ Wallet.prototype.onExecute = async function () {
         this.onAction();
         let currentWeb3 = new Web3(window.web3);
         let balance = await currentWeb3.eth.getBalance(args.address);
-        let eth_balance = currentWeb3.utils.fromWei(balance)
-        return eth_balance;
+        return balance
       } catch (e) {
         console.log(e);
       }
@@ -92,8 +91,8 @@ Wallet.prototype.onExecute = async function () {
     args: [{ name: "message", type: "string" }],
     function: async (args) => {
       return new Promise((resolve, reject) => {
-        let currentWeb3 = new Web3(window.web3);
         this.onAction();
+        let currentWeb3 = new Web3(window.web3);
         window.ethereum.sendAsync(
           {
             method: "personal_sign",


### PR DESCRIPTION
* Update window.web3 to window.ethereum
* Update window.ethereum.request from deprecated sendAsync
* update provider detection to use @metamask/detect-provider and set current account logic
* update balance - get current balance of selected account
                              - display in ether instead of Wei for visibility
                              - remove address argument to reflect metamask current account 
* update personal_sign - fix callback function
                                         - change personal signed result process to verify current account is signed verifier using eth-sig-util
* update sendTransaction - fix callback function
                                             - change input value to ether from wei
* update signedTypeData - fix callback function